### PR TITLE
add headers to transaction request debug logs

### DIFF
--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -101,8 +101,9 @@ export default class HttpConnection extends Connection {
 
             const res = await fetch(request.url, request)
             const { body: rawQueryResponse, headers: [contentType] } = await readBodyAndReaders<RawQueryResponse>(request.url, res, 'content-type')
-            
-            this._log?.debug(`${this} ${JSON.stringify(rawQueryResponse)}`)
+            let headers = ""
+            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
+            this._log?.debug(`${this} ${JSON.stringify(rawQueryResponse)} ${headers}`);
             const batchSize = config?.fetchSize ?? Number.MAX_SAFE_INTEGER
             const codec = QueryResponseCodec.of(this._config, contentType ?? '', rawQueryResponse);
 
@@ -191,7 +192,9 @@ export default class HttpConnection extends Connection {
                 headers: [contentType, affinity]
             } = await readBodyAndReaders<RawBeginTransactionResponse>(request.url, res, 'content-type', this._sessionAffinityHeader)
 
-            this._log?.debug(`${this} ${JSON.stringify(rawBeginTransactionResponse)}`)
+            let headers = ""
+            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
+            this._log?.debug(`${this} ${JSON.stringify(rawBeginTransactionResponse)} ${headers} `);
             
             const codec = BeginTransactionResponseCodec.of(this._config, contentType ?? '', rawBeginTransactionResponse);
 
@@ -255,7 +258,9 @@ export default class HttpConnection extends Connection {
                 headers: [contentType]
             } = await readBodyAndReaders<RawCommitTransactionResponse>(request.url, res, 'contentType')
 
-            this._log?.debug(`${this} ${JSON.stringify(rawCommitTransactionResponse)}`)
+            let headers = ""
+            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
+            this._log?.debug(`${this} ${JSON.stringify(rawCommitTransactionResponse)} ${headers}`);
             
             const codec = CommitTransactionResponseCodec.of(this._config, contentType ?? '', rawCommitTransactionResponse);
 
@@ -311,7 +316,9 @@ export default class HttpConnection extends Connection {
                 ]
             } = await readBodyAndReaders<RawRollbackTransactionResponse>(request.url, res, 'content-type')
 
-            this._log?.debug(`${this} ${JSON.stringify(rawRollbackTransactionResponse)}`)
+            let headers = ""
+            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
+            this._log?.debug(`${this} ${headers} ${JSON.stringify(rawRollbackTransactionResponse)}`);
             
             const codec = RollbackTransactionResponseCodec.of(this._config, contentType ?? '', rawRollbackTransactionResponse);
 

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -101,9 +101,9 @@ export default class HttpConnection extends Connection {
 
             const res = await fetch(request.url, request)
             const { body: rawQueryResponse, headers: [contentType] } = await readBodyAndReaders<RawQueryResponse>(request.url, res, 'content-type')
-            let headers = ""
-            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
-            this._log?.debug(`${this} ${JSON.stringify(rawQueryResponse)} ${headers}`);
+            
+            this._log?.debug(`${this} { body: ${JSON.stringify(rawQueryResponse)}, headers: { content-type: ${contentType} }}`);
+            
             const batchSize = config?.fetchSize ?? Number.MAX_SAFE_INTEGER
             const codec = QueryResponseCodec.of(this._config, contentType ?? '', rawQueryResponse);
 
@@ -192,9 +192,7 @@ export default class HttpConnection extends Connection {
                 headers: [contentType, affinity]
             } = await readBodyAndReaders<RawBeginTransactionResponse>(request.url, res, 'content-type', this._sessionAffinityHeader)
 
-            let headers = ""
-            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
-            this._log?.debug(`${this} ${JSON.stringify(rawBeginTransactionResponse)} ${headers} `);
+            this._log?.debug(`${this} { body: ${JSON.stringify(rawBeginTransactionResponse)}, headers: { content-type: ${contentType}, ${this._sessionAffinityHeader}: ${affinity} }}`);
             
             const codec = BeginTransactionResponseCodec.of(this._config, contentType ?? '', rawBeginTransactionResponse);
 
@@ -258,9 +256,7 @@ export default class HttpConnection extends Connection {
                 headers: [contentType]
             } = await readBodyAndReaders<RawCommitTransactionResponse>(request.url, res, 'contentType')
 
-            let headers = ""
-            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
-            this._log?.debug(`${this} ${JSON.stringify(rawCommitTransactionResponse)} ${headers}`);
+            this._log?.debug(`${this} { body: ${JSON.stringify(rawCommitTransactionResponse)}, headers: { content-type: ${contentType} }}`);
             
             const codec = CommitTransactionResponseCodec.of(this._config, contentType ?? '', rawCommitTransactionResponse);
 
@@ -316,9 +312,7 @@ export default class HttpConnection extends Connection {
                 ]
             } = await readBodyAndReaders<RawRollbackTransactionResponse>(request.url, res, 'content-type')
 
-            let headers = ""
-            res.headers.forEach((value, header) => headers += `\nHeader: ${header} Value: ${value}`)
-            this._log?.debug(`${this} ${headers} ${JSON.stringify(rawRollbackTransactionResponse)}`);
+            this._log?.debug(`${this} { body: ${JSON.stringify(rawRollbackTransactionResponse)}, headers: { content-type: ${contentType} }}`);
             
             const codec = RollbackTransactionResponseCodec.of(this._config, contentType ?? '', rawRollbackTransactionResponse);
 

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -102,7 +102,7 @@ export default class HttpConnection extends Connection {
             const res = await fetch(request.url, request)
             const { body: rawQueryResponse, headers: [contentType] } = await readBodyAndReaders<RawQueryResponse>(request.url, res, 'content-type')
             
-            this._log?.debug(`${this} { body: ${JSON.stringify(rawQueryResponse)}, headers: { content-type: ${contentType} }}`);
+            this._log?.debug(`${this} RESPONSE: { body: ${JSON.stringify(rawQueryResponse)}, headers: { content-type: ${contentType} }}`);
             
             const batchSize = config?.fetchSize ?? Number.MAX_SAFE_INTEGER
             const codec = QueryResponseCodec.of(this._config, contentType ?? '', rawQueryResponse);
@@ -192,7 +192,7 @@ export default class HttpConnection extends Connection {
                 headers: [contentType, affinity]
             } = await readBodyAndReaders<RawBeginTransactionResponse>(request.url, res, 'content-type', this._sessionAffinityHeader)
 
-            this._log?.debug(`${this} { body: ${JSON.stringify(rawBeginTransactionResponse)}, headers: { content-type: ${contentType}, ${this._sessionAffinityHeader}: ${affinity} }}`);
+            this._log?.debug(`${this} RESPONSE: { body: ${JSON.stringify(rawBeginTransactionResponse)}, headers: { content-type: ${contentType}, ${this._sessionAffinityHeader}: ${affinity} }}`);
             
             const codec = BeginTransactionResponseCodec.of(this._config, contentType ?? '', rawBeginTransactionResponse);
 
@@ -256,7 +256,7 @@ export default class HttpConnection extends Connection {
                 headers: [contentType]
             } = await readBodyAndReaders<RawCommitTransactionResponse>(request.url, res, 'contentType')
 
-            this._log?.debug(`${this} { body: ${JSON.stringify(rawCommitTransactionResponse)}, headers: { content-type: ${contentType} }}`);
+            this._log?.debug(`${this} RESPONSE: { body: ${JSON.stringify(rawCommitTransactionResponse)}, headers: { content-type: ${contentType} }}`);
             
             const codec = CommitTransactionResponseCodec.of(this._config, contentType ?? '', rawCommitTransactionResponse);
 
@@ -312,7 +312,7 @@ export default class HttpConnection extends Connection {
                 ]
             } = await readBodyAndReaders<RawRollbackTransactionResponse>(request.url, res, 'content-type')
 
-            this._log?.debug(`${this} { body: ${JSON.stringify(rawRollbackTransactionResponse)}, headers: { content-type: ${contentType} }}`);
+            this._log?.debug(`${this} RESPONSE: { body: ${JSON.stringify(rawRollbackTransactionResponse)}, headers: { content-type: ${contentType} }}`);
             
             const codec = RollbackTransactionResponseCodec.of(this._config, contentType ?? '', rawRollbackTransactionResponse);
 


### PR DESCRIPTION
The wrapper is currently only logging the body of responses it receives, this made debugging the clustering CORS bug a headache, this PR modifies the logs to include headers in debug logging

Changes the logs from

> HttpConnection [0] {"errors":[{"code":"Neo.ClientError.Request.Invalid","message":"Transaction with Id: \"4bcb\" was not found. It may have timed out and therefore rolled back or the routing header 'neo4j-cluster-affinity' was not provided."}]}

to 

> HttpConnection [0] RESPONSE: { body: {"errors":[{"code":"Neo.ClientError.Request.Invalid","message":"Transaction with Id: \"4bcb\" was not found. It may have timed out and therefore rolled back or the routing header 'neo4j-cluster-affinity' was not provided."}]} headers: { content-type: application/vnd.neo4j.query }}