### PR TITLE
Double base64 encoding of bearer tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-labs/experimental-query-api-wrapper",
-  "version": "0.0.1-alpha07",
+  "version": "0.0.1-alpha08",
   "description": "Experimental wrapper library to access Neo4j Database using Query API with a neo4j-driver-like interface.",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/http-connection/codec.ts
+++ b/src/http-connection/codec.ts
@@ -24,7 +24,7 @@ export const NEO4J_QUERY_CONTENT_TYPE = 'application/vnd.neo4j.query'
 export function encodeAuthToken(auth: types.AuthToken): string {
     switch (auth.scheme) {
         case 'bearer':
-            return `Bearer ${btoa(auth.credentials)}`
+            return `Bearer ${auth.credentials}`
         case 'basic':
             return `Basic ${btoa(`${auth.principal}:${auth.credentials}`)}`
         default:

--- a/test/integration/config/stubs/affinity_header_begin.stub.json
+++ b/test/integration/config/stubs/affinity_header_begin.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             }
         },
         "bodyPatterns": [

--- a/test/integration/config/stubs/affinity_header_begin_read.stub.json
+++ b/test/integration/config/stubs/affinity_header_begin_read.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             }
         },
         "bodyPatterns": [

--- a/test/integration/config/stubs/affinity_header_commit.stub.json
+++ b/test/integration/config/stubs/affinity_header_commit.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             },
             "Neo4j-Cluster-Affinity": {
                 "equalTo": "123abc"

--- a/test/integration/config/stubs/affinity_header_return_1.stub.json
+++ b/test/integration/config/stubs/affinity_header_return_1.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             },
             "Neo4j-Cluster-Affinity": {
                 "equalTo": "123abc"

--- a/test/integration/config/stubs/session_run_bearer_token_impersonated_return_1.stub.json
+++ b/test/integration/config/stubs/session_run_bearer_token_impersonated_return_1.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             }
         },
         "bodyPatterns": [

--- a/test/integration/config/stubs/session_run_bearer_token_return_1.stub.json
+++ b/test/integration/config/stubs/session_run_bearer_token_return_1.stub.json
@@ -10,7 +10,7 @@
                 "equalTo": "application/vnd.neo4j.query, application/json"
             },
             "Authorization": {
-                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+                "equalTo": "Bearer nicestTokenEver"
             }
         },
         "bodyPatterns": [

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -41,9 +41,9 @@ describe('QueryRequestCodec', () => {
     describe('.authorization', () => {
         it.each([
             ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer mytoken'],
             ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer mytoken'],
         ])('should handle %s', (_, auth, expected) => {
             const codec = subject({ auth })
 

--- a/test/unit/http-connection/transaction.codec.test.ts
+++ b/test/unit/http-connection/transaction.codec.test.ts
@@ -54,9 +54,9 @@ describe('BeginTransactionRequestCodec', () => {
     describe('.authorization', () => {
         it.each([
             ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer mytoken'],
             ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer mytoken'],
         ])('should handle %s', (_, auth, expected) => {
             const codec = subject({ auth })
 
@@ -283,9 +283,9 @@ describe('CommitTransactionRequestCodec', () => {
     describe('.authorization', () => {
         it.each([
             ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer mytoken'],
             ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer mytoken'],
         ])('should handle %s', (_, auth, expected) => {
             const codec = subject({ auth })
 
@@ -440,9 +440,9 @@ describe('RollbackTransactionRequestCodec', () => {
     describe('.authorization', () => {
         it.each([
             ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer mytoken'],
             ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
-            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer mytoken'],
         ])('should handle %s', (_, auth, expected) => {
             const codec = subject({ auth })
 


### PR DESCRIPTION
Fixes bearer tokens which were being base64 encoded by the wrapper, despite already asking for the token in base64 encoded form.

Also bumps the reported version to prepare for a patch release
