### PR TITLE
Blocking UnsupportedType to be ingrested as param

### DIFF
--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { newError, Node, Relationship, int, error, types, Integer, Time, Date, LocalTime, Point, DateTime, LocalDateTime, Duration, isInt, isPoint, isDuration, isLocalTime, isTime, isDate, isLocalDateTime, isDateTime, isRelationship, isPath, isNode, isPathSegment, Path, PathSegment, internal, isUnboundRelationship, isVector } from "neo4j-driver-core"
+import { newError, Node, Relationship, int, error, types, Integer, Time, Date, LocalTime, Point, DateTime, LocalDateTime, Duration, isInt, isPoint, isDuration, isLocalTime, isTime, isDate, isLocalDateTime, isDateTime, isRelationship, isPath, isNode, isPathSegment, Path, PathSegment, internal, isUnboundRelationship, isVector, isUnsupportedType } from "neo4j-driver-core"
 import { RunQueryConfig } from "neo4j-driver-core/types/connection"
 import { NEO4J_QUERY_CONTENT_TYPE, encodeAuthToken, encodeTransactionBody } from "./codec"
 
@@ -769,6 +769,8 @@ export class QueryRequestCodec {
             return { $type: 'OffsetDateTime', _value: value.toString() }
         } else if (isVector(value)) {
             throw newError('Vectors are not supported yet on query api', error.PROTOCOL_ERROR)
+        } else if (isUnsupportedType(value)) {
+            throw newError('UnsupportedType can not be ingested to the server', error.PROTOCOL_ERROR)
         } else if (isRelationship(value) || isNode(value) || isPath(value) || isPathSegment(value) || isUnboundRelationship(value)) {
             throw newError('Graph types can not be ingested to the server', error.PROTOCOL_ERROR) 
         } else if (typeof value === 'object') {

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import neo4j, { auth, types, internal, int, Date, Time, LocalTime, DateTime, LocalDateTime, Point, Duration, Node, Relationship, UnboundRelationship, Path, PathSegment, Vector } from "neo4j-driver-core";
+import neo4j, { auth, types, internal, int, Date, Time, LocalTime, DateTime, LocalDateTime, Point, Duration, Node, Relationship, UnboundRelationship, Path, PathSegment, Vector, UnsupportedType } from "neo4j-driver-core";
 import { QueryRequestCodec, QueryRequestCodecConfig, QueryResponseCodec, RawQueryResponse, RawQueryValue } from "../../../src/http-connection/query.codec";
 
 describe('QueryRequestCodec', () => {
@@ -208,6 +208,17 @@ describe('QueryRequestCodec', () => {
             })
 
             expect(() => codec.body).toThrow('Graph types can not be ingested to the server')
+        })
+
+        it('should not handle UnsupportedType as parameters ', () => {
+            const param = new UnsupportedType("Vector", 6, 0, "Something good is bad, actually!")
+            const codec = subject({
+                parameters: {
+                    param
+                }
+            })
+
+            expect(() => codec.body).toThrow('UnsupportedType can not be ingested to the server')
         })
 
         it.each([


### PR DESCRIPTION
This change blocks the UnsupportedType to be send as Map to the http server.
This doesn't mean that it will get written to entities since maps can't be written to those.
However, this introduces a better error message and avoids it be wrongly send for any other routine.